### PR TITLE
Fix for remove reverse permission issue

### DIFF
--- a/contracts/SimpleRegistry.sol
+++ b/contracts/SimpleRegistry.sol
@@ -180,6 +180,7 @@ contract SimpleRegistry is Owned, MetadataRegistry, OwnerRegistry, ReverseRegist
 	function removeReverse()
 		external
 		whenEntry(reverses[msg.sender])
+		onlyOwnerOf(keccak256(bytes(reverses[msg.sender])))
 	{
 		emit ReverseRemoved(reverses[msg.sender], msg.sender);
 		delete entries[keccak256(bytes(reverses[msg.sender]))].reverse;


### PR DESCRIPTION
This adds the `onlyOwnerOf` modifier to the `removeReverse` function so that only the owner of a particular name can delete the reverse mapping.